### PR TITLE
bug on mysql configuration in application.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>net.csdn</groupId>
     <artifactId>ActiveORM</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -124,8 +124,23 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <compilerArgument>-g</compilerArgument>
+                    <verbose>true</verbose>
+                    <encoding>UTF-8</encoding>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/net/csdn/jpa/type/DBInfo.java
+++ b/src/main/java/net/csdn/jpa/type/DBInfo.java
@@ -43,6 +43,8 @@ public class DBInfo {
         Class.forName("com.mysql.jdbc.Driver").newInstance();
         Map<String, Settings> groups = settings.getGroups(JPA.mode() + ".datasources");
         Settings mysqlSetting = groups.get("mysql");
+        if(mysqlSetting == null){return;}
+
         String url = "jdbc:mysql://{}:{}/{}?useUnicode=true&characterEncoding=utf8";
         url = format(url, mysqlSetting.get("host", "127.0.0.1"), mysqlSetting.get("port", "3306"), mysqlSetting.get("database", "csdn_search_client"));
         conn = DriverManager.getConnection(url, mysqlSetting.get("username"), mysqlSetting.get("password"));


### PR DESCRIPTION
if in application.yml 

config like:

> production:
>     datasources:
>         multi-mysql:

but without:

> production:
>     datasources:
>         mysql:

then when app started, it emits exceptions like(though the app still works despite exceptions): 

> java.lang.NullPointerException
>     at net.csdn.jpa.type.DBInfo.info(DBInfo.java:47)
>     at net.csdn.jpa.type.DBInfo.<init>(DBInfo.java:33)
>     at net.csdn.jpa.JPA$CSDNORMConfiguration.buildDefaultDBInfo(JPA.java:322)
>     at net.csdn.jpa.JPA.configure(JPA.java:75)
